### PR TITLE
Updates to MATLAB LTE streaming demo

### DIFF
--- a/hil_models/LTE_MATLAB/LTEReceiver.m
+++ b/hil_models/LTE_MATLAB/LTEReceiver.m
@@ -104,7 +104,14 @@ rmc = lteRMCDL(configuration);
 rmc.NCellID = 17;
 rmc.NFrame = 700;
 rmc.TotSubframes = 8*10; % 10 subframes per frame
-rmc.OCNG = 'On'; % Add noise to unallocated PDSCH resource elements
+
+% Add noise to unallocated PDSCH resource elements
+if verLessThan('matlab','9.2')
+    rmc.OCNG = 'On';
+else
+    rmc.OCNGPDSCHEnable = 'On';
+    rmc.OCNGPDCCHEnable = 'On';
+end
 
 % Generate RMC waveform
 trData = [1;0;0;1]; % Transport data


### PR DESCRIPTION
Updates to MATLAB LTE streaming demo. Fixes some warnings caused by newer versions of ML and separates TX and RX system objects for better streaming performance.

Signed-off-by: Travis Collins <travis.collins@analog.com>