### PR TITLE
Enabling shared object state for TX and RX pairs

### DIFF
--- a/+adi/+AD9144/Tx.m
+++ b/+adi/+AD9144/Tx.m
@@ -39,25 +39,6 @@ classdef Tx < adi.AD9144.Base & adi.common.Tx & adi.common.DDS
         end
     end
     
-    %% API Functions
-    methods (Hidden, Access = protected)
-        
-        function setupImpl(obj,data)
-            if strcmp(obj.DataSource,'DMA')
-                obj.SamplesPerFrame = size(data,1);
-            end
-            % Call the superclass method
-            setupImpl@matlabshared.libiio.base(obj);
-        end
-        
-        % Hide unused parameters when in specific modes
-        function flag = isInactivePropertyImpl(obj, prop)
-            % Call the superclass method
-            flag = isInactivePropertyImpl@adi.common.RxTx(obj,prop);
-        end
-        
-    end
-    
     %% External Dependency Methods
     methods (Hidden, Static)
         

--- a/+adi/+AD9361/Base.m
+++ b/+adi/+AD9361/Base.m
@@ -1,5 +1,5 @@
 classdef (Abstract, Hidden = true) Base < adi.common.Attribute & ...
-        adi.common.DebugAttribute & ...
+        adi.common.DebugAttribute & adi.common.RxTx & ...
         matlabshared.libiio.base & matlab.system.mixin.CustomIcon
 
     %adi.AD9361.Base Class
@@ -62,6 +62,7 @@ classdef (Abstract, Hidden = true) Base < adi.common.Attribute & ...
         % Destructor
         function delete(obj)
             teardownLibad9361(obj);
+            delete@adi.common.RxTx(obj);
         end
         % Check SamplesPerFrame
         function set.SamplesPerFrame(obj, value)

--- a/+adi/+AD9361/Rx.m
+++ b/+adi/+AD9361/Rx.m
@@ -1,5 +1,5 @@
 classdef Rx < adi.AD9361.Base & adi.AD9361.TuneAGC & ...
-        adi.common.Rx & matlab.system.mixin.SampleTime
+        adi.common.Rx
     % adi.AD9361.Rx Receive data from the AD9361 transceiver
     %   The adi.AD9361.Rx System object is a signal source that can receive
     %   complex data from the AD9361.
@@ -243,11 +243,6 @@ classdef Rx < adi.AD9361.Base & adi.AD9361.TuneAGC & ...
     
     %% API Functions
     methods (Hidden, Access = protected)
-        
-        function sts = getSampleTimeImpl(obj)
-            sts = createSampleTime(obj,'Type','Discrete',...
-                'SampleTime',obj.SamplesPerFrame/obj.SamplingRate);
-        end
                 
         function setupInit(obj)
             % Write all attributes to device once connected through set

--- a/+adi/+AD9361/Tx.m
+++ b/+adi/+AD9361/Tx.m
@@ -137,34 +137,9 @@ classdef Tx < adi.AD9361.Base & adi.common.Tx
             end
         end
     end
-    
-    methods (Access=protected)
-        function setupImpl(obj,data)
-            if strcmp(obj.DataSource,'DMA')
-                obj.SamplesPerFrame = size(data,1);
-            end
-            % Call the superclass method
-            setupImpl@matlabshared.libiio.base(obj);
-        end
-
-        % Hide unused parameters when in specific modes
-        function flag = isInactivePropertyImpl(obj, prop)
-            % Call the superclass method
-            flag = isInactivePropertyImpl@adi.common.RxTx(obj,prop);
-        end
-        
-    end
-    
+       
     %% API Functions
     methods (Hidden, Access = protected)
-        
-        function numIn = getNumInputsImpl(obj)
-            if strcmp(obj.DataSource,'DDS')
-                numIn = 0;
-            else
-                numIn = obj.channelCount/2;
-            end
-        end
         
         function setupInit(obj)
             % Write all attributes to device once connected through set

--- a/+adi/+AD9371/Base.m
+++ b/+adi/+AD9371/Base.m
@@ -56,9 +56,6 @@ classdef (Abstract, Hidden = true) Base < adi.common.Attribute & matlabshared.li
             coder.allowpcode('plain');
             obj = obj@matlabshared.libiio.base(varargin{:});
         end
-        % Destructor
-        function delete(~)
-        end
         % Check SamplesPerFrame
         function set.SamplesPerFrame(obj, value)
             validateattributes( value, { 'double','single' }, ...
@@ -152,6 +149,15 @@ classdef (Abstract, Hidden = true) Base < adi.common.Attribute & matlabshared.li
 
         
         function writeProfileFile(obj)
+            if obj.Count() > 1
+                [~,props] = obj.Count(0,obj,'EnableCustomProfile');
+                if any(props{:})
+                   warning('AD9371:Profile:RXTX',...
+                       ['Existing objects in the workspace have written profiles.\n',...
+                       'Doing so again can have undesirable side affects.\n',...
+                       'First stepped object should only set profile.']); 
+                end
+            end            
             profle_data_str = fileread(obj.CustomProfileFileName);
             % Wrap update in read writes since once profiles are loaded
             % some attributes get lost

--- a/+adi/+AD9371/ORx.m
+++ b/+adi/+AD9371/ORx.m
@@ -1,4 +1,4 @@
-classdef ORx < adi.AD9371.Base & adi.common.Rx & matlab.system.mixin.SampleTime
+classdef ORx < adi.AD9371.Base & adi.common.Rx
     % adi.AD9371.ORx Receive data from the AD9371 transceiver observation receiver
     %   The adi.AD9371.ORx System object is a signal source that can receive
     %   complex data from the AD9371. This object is used for both
@@ -93,7 +93,7 @@ classdef ORx < adi.AD9371.Base & adi.common.Rx & matlab.system.mixin.SampleTime
     
     methods
         %% Constructor
-        function obj = Obs(varargin)
+        function obj = ORx(varargin)
             coder.allowpcode('plain');
             obj = obj@adi.AD9371.Base(varargin{:});
         end
@@ -152,16 +152,7 @@ classdef ORx < adi.AD9371.Base & adi.common.Rx & matlab.system.mixin.SampleTime
     
     %% API Functions
     methods (Hidden, Access = protected)
-        
-        function sts = getSampleTimeImpl(obj)
-            sts = createSampleTime(obj,'Type','Discrete',...
-                'SampleTime',obj.SamplesPerFrame/obj.SamplingRate);
-        end
-        
-        function numOut = getNumOutputsImpl(obj)
-            numOut = obj.channelCount/2 + 1; % +1 for valid
-        end
-        
+                
         function setupInit(obj)
             % Write all attributes to device once connected through set
             % methods

--- a/+adi/+AD9371/Rx.m
+++ b/+adi/+AD9371/Rx.m
@@ -1,4 +1,4 @@
-classdef Rx < adi.AD9371.Base & adi.common.Rx & matlab.system.mixin.SampleTime
+classdef Rx < adi.AD9371.Base & adi.common.Rx
     % adi.AD9371.Rx Receive data from the AD9371 transceiver
     %   The adi.AD9371.Rx System object is a signal source that can receive
     %   complex data from the AD9371.
@@ -117,11 +117,6 @@ classdef Rx < adi.AD9371.Base & adi.common.Rx & matlab.system.mixin.SampleTime
         
     %% API Functions
     methods (Hidden, Access = protected)
-        
-        function sts = getSampleTimeImpl(obj)
-            sts = createSampleTime(obj,'Type','Discrete',...
-                'SampleTime',obj.SamplesPerFrame/obj.SamplingRate);
-        end
         
         function setupInit(obj)
             % Write all attributes to device once connected through set

--- a/+adi/+AD9371/Tx.m
+++ b/+adi/+AD9371/Tx.m
@@ -64,24 +64,7 @@ classdef Tx < adi.AD9371.Base & adi.common.Tx
         end
         
     end
-    
-    methods (Access=protected)
-        function setupImpl(obj,data)
-            if strcmp(obj.DataSource,'DMA')
-                obj.SamplesPerFrame = size(data,1);
-            end
-            % Call the superclass method
-            setupImpl@matlabshared.libiio.base(obj);
-        end
-
-        % Hide unused parameters when in specific modes
-        function flag = isInactivePropertyImpl(obj, prop)
-            % Call the superclass method
-            flag = isInactivePropertyImpl@adi.common.RxTx(obj,prop);
-        end
         
-    end
-    
     %% API Functions
     methods (Hidden, Access = protected)
                 

--- a/+adi/+AD9680/Rx.m
+++ b/+adi/+AD9680/Rx.m
@@ -36,74 +36,7 @@ classdef Rx < adi.AD9680.Base & adi.common.Rx
             coder.allowpcode('plain');
             obj = obj@adi.AD9680.Base(varargin{:});
         end
-    end
-    
-    %% API Functions
-    methods (Hidden, Access = protected)
-        
-        function numOut = getNumOutputsImpl(obj)
-            numOut = ceil(obj.channelCount/2) + 1; % +1 for valid
-        end
-        
-        % Hide unused parameters when in specific modes
-        function flag = isInactivePropertyImpl(obj, prop)
-            % Call the superclass method
-            flag = isInactivePropertyImpl@adi.common.RxTx(obj,prop);
-        end
-    end
-    
-    methods (Access=protected)
-        
-        function varargout = getOutputNamesImpl(obj)
-            % Return output port names for System block
-            numOut = ceil(obj.channelCount/2) + 1; % +1 for valid
-            varargout = cell(1,numOut);
-            for k=1:numOut-1
-                varargout{k} = ['chan',num2str(k)];
-            end
-            varargout{numOut} = 'valid';
-        end
-        
-        function varargout = getOutputSizeImpl(obj)
-            % Return size for each output port
-            numOut = ceil(obj.channelCount/2) + 1; % +1 for valid
-            varargout = cell(1,numOut);
-            for k=1:numOut-1
-                varargout{k} = [obj.SamplesPerFrame,1];
-            end
-            varargout{numOut} = [1,1];
-        end
-        
-        function varargout = getOutputDataTypeImpl(obj)
-            % Return data type for each output port
-            numOut = ceil(obj.channelCount/2) + 1; % +1 for valid
-            varargout = cell(1,numOut);
-            for k=1:numOut-1
-                varargout{k} = "int16";
-            end
-            varargout{numOut} = "logical";
-        end
-        
-        function varargout = isOutputComplexImpl(obj)
-            % Return true for each output port with complex data
-            numOut = ceil(obj.channelCount/2) + 1; % +1 for valid
-            varargout = cell(1,numOut);
-            for k=1:numOut-1
-                varargout{k} = true;
-            end
-            varargout{numOut} = false;
-        end
-        
-        function varargout = isOutputFixedSizeImpl(obj)
-            % Return true for each output port with fixed size
-            numOut = ceil(obj.channelCount/2) + 1; % +1 for valid
-            varargout = cell(1,numOut);
-            for k=1:numOut
-                varargout{k} = true;
-            end
-        end
-    end
-    
+    end   
     
     %% External Dependency Methods
     methods (Hidden, Static)

--- a/+adi/+ADRV9009/Base.m
+++ b/+adi/+ADRV9009/Base.m
@@ -57,9 +57,6 @@ classdef (Abstract, Hidden = true) Base < adi.common.Attribute & matlabshared.li
             coder.allowpcode('plain');
             obj = obj@matlabshared.libiio.base(varargin{:});
         end
-        % Destructor
-        function delete(~)
-        end
         % Check SamplesPerFrame
         function set.SamplesPerFrame(obj, value)
             validateattributes( value, { 'double','single' }, ...

--- a/+adi/+ADRV9009/Rx.m
+++ b/+adi/+ADRV9009/Rx.m
@@ -1,4 +1,4 @@
-classdef Rx < adi.ADRV9009.Base & adi.common.Rx & matlab.system.mixin.SampleTime
+classdef Rx < adi.ADRV9009.Base & adi.common.Rx
     % adi.ADRV9009.Rx Receive data from the ADRV9009 transceiver
     %   The adi.ADRV9009.Rx System object is a signal source that can receive
     %   complex data from the ADRV9009.
@@ -117,12 +117,7 @@ classdef Rx < adi.ADRV9009.Base & adi.common.Rx & matlab.system.mixin.SampleTime
        
     %% API Functions
     methods (Hidden, Access = protected)
-        
-        function sts = getSampleTimeImpl(obj)
-            sts = createSampleTime(obj,'Type','Discrete',...
-                'SampleTime',obj.SamplesPerFrame/obj.SamplingRate);
-        end
-        
+
         function setupInit(obj)
             % Write all attributes to device once connected through set
             % methods

--- a/+adi/+ADRV9009/Tx.m
+++ b/+adi/+ADRV9009/Tx.m
@@ -65,23 +65,6 @@ classdef Tx < adi.ADRV9009.Base & adi.common.Tx
         
     end
     
-    methods (Access=protected)
-        function setupImpl(obj,data)
-            if strcmp(obj.DataSource,'DMA')
-                obj.SamplesPerFrame = size(data,1);
-            end
-            % Call the superclass method
-            setupImpl@matlabshared.libiio.base(obj);
-        end
-
-        % Hide unused parameters when in specific modes
-        function flag = isInactivePropertyImpl(obj, prop)
-            % Call the superclass method
-            flag = isInactivePropertyImpl@adi.common.RxTx(obj,prop);
-        end
-        
-    end
-    
     %% API Functions
     methods (Hidden, Access = protected)
         

--- a/+adi/+common/Rx.m
+++ b/+adi/+common/Rx.m
@@ -1,4 +1,4 @@
-classdef (Abstract) Rx  < adi.common.RxTx
+classdef (Abstract) Rx  < adi.common.RxTx & matlab.system.mixin.SampleTime
     % Rx: Common shared functions between receiver classes
     properties(Constant, Hidden, Logical)
         %EnableCyclicBuffers Enable Cyclic Buffers
@@ -6,8 +6,17 @@ classdef (Abstract) Rx  < adi.common.RxTx
         EnableCyclicBuffers = false;
     end
     
+    methods (Hidden, Access = protected)
+        
+        function sts = getSampleTimeImpl(obj)
+            sts = createSampleTime(obj,'Type','Discrete',...
+                'SampleTime',obj.SamplesPerFrame/obj.SamplingRate);
+        end
+        
+    end
+    
     methods (Access=protected)
-
+        
         function numOut = getNumOutputsImpl(~)
             numOut = 2;
         end

--- a/+adi/+common/Tx.m
+++ b/+adi/+common/Tx.m
@@ -14,6 +14,14 @@ classdef (Abstract) Tx  < adi.common.RxTx & adi.common.DDS
     end
     
     methods (Hidden, Access = protected)
+
+        function setupImpl(obj,data)
+            if strcmp(obj.DataSource,'DMA')
+                obj.SamplesPerFrame = size(data,1);
+            end
+            % Call the superclass method
+            setupImpl@adi.common.RxTx(obj);
+        end
         
         function valid = stepImpl(obj,dataIn)
             % valid = tx(data) returns a logical value that indicates

--- a/test/AD9361Tests.m
+++ b/test/AD9361Tests.m
@@ -46,6 +46,42 @@ classdef AD9361Tests < HardwareTests
             testCase.verifyGreaterThan(sum(abs(double(out))),0);
         end
         
+        function testAD9361RxClearing(testCase)
+            % Verify clearing of system objects is working in all cases
+            rx = adi.AD9361.Rx();
+            rx.uri = testCase.uri;
+            if rx.Count ~= 0
+                error('e1');
+            end
+            rx();
+            if rx.Count ~= 1
+                error('e2');
+            end
+            rx.release();
+            if rx.Count ~= 0
+                error('e3');
+            end
+            %
+            rx = adi.AD9361.Rx();
+            rx.uri = testCase.uri;
+            if rx.Count ~= 0
+                error('e4');
+            end
+            rx();
+            delete(rx)
+            rx = adi.AD9361.Rx();
+            rx.uri = testCase.uri;
+            if rx.Count ~= 0
+                error('e5');
+            end
+            rx();            
+            if rx.Count ~= 1
+                error('e6');
+            end
+            %
+            rx.release();
+        end
+        
         function testAD9361RxWithTxDDS(testCase)
             % Test DDS output
             tx = adi.AD9361.Tx('uri',testCase.uri);

--- a/test/AD9371Tests.m
+++ b/test/AD9371Tests.m
@@ -150,6 +150,31 @@ classdef AD9371Tests < HardwareTests
                 'Invalid sample rate after profile write');
         end
         
+        function testAD9371RxTxProfileWarnings(testCase)
+            rx = adi.AD9371.Rx;
+            rx.uri = testCase.uri;
+            rx.EnableCustomProfile = true;
+            rx.CustomProfileFileName = ...
+                'profile_TxBW50_ORxBW50_RxBW50.txt';
+            tx = adi.AD9371.Tx;
+            tx.uri = testCase.uri;
+            tx.EnabledChannels = 1;
+            tx.EnableCustomProfile = true;
+            tx.CustomProfileFileName = ...
+                'profile_TxBW50_ORxBW50_RxBW50.txt';
+            
+            testCase.verifyWarning(@RunTxRx,'AD9371:Profile:RXTX',...
+                'No expected warning issued');
+            
+            function RunTxRx
+                rx();
+                tx(complex(randn(1024,1)));
+                rx.release();
+                tx.release();
+            end
+            
+        end
+        
         function testAD9371RxWithTxDDS(testCase)
             % Test assumes RX1 and TX1 are connected through a cable
             % Test DDS output


### PR DESCRIPTION
Changes allow handling of state across pairs of Tx and Rx classes. This is important for handling things like profiles which affect both classes. This required some cleanup of deconstructor logic to gracefully handle instantiation of classes. Tests have been added to check corner cases and checks for clear object cleanup.

Signed-off-by: Travis F. Collins <travis.collins@analog.com>